### PR TITLE
Update to 0.86.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # streamlit-cheat-sheet
 A cheat sheet for Streamlit
-v0.81.0 (versions now aligned to Streamlit versioning)
+v0.86.0 (versions now aligned to Streamlit versioning)
 
 # Versioning
-* Based on Streamlit 0.81.0
+* Based on Streamlit 0.86.0
 * Made with Python 3.8.5
 
 # Requirements

--- a/app.py
+++ b/app.py
@@ -170,6 +170,12 @@ st.color_picker('Pick a color')
 >>> my_slider_val = st.slider('Quinn Mallory', 1, 88)
 >>> st.write(slider_val)
     ''')
+    col2.write('Batch widgets together in a form:')
+    col2.code('''
+>>> with st.form(key='my_form'):
+>>> 	text_input = st.text_input(label='Enter some text')
+>>> 	submit_button = st.form_submit_button(label='Submit')
+    ''')
 
     # Control flow
 
@@ -182,12 +188,12 @@ st.stop()
 
     col2.subheader('Lay out your app')
     col2.code('''
-st.beta_container()
-st.beta_columns(spec)
->>> col1, col2 = st.beta_columns(2)
+st.container()
+st.columns(spec)
+>>> col1, col2 = st.columns(2)
 >>> col1.subheader('Columnisation')
-st.beta_expander('Expander')
->>> with st.beta_expander('Expand'):
+st.expander('Expander')
+>>> with st.expander('Expand'):
 >>>     st.write('Juicy deets')
     ''')
 

--- a/app.py
+++ b/app.py
@@ -266,6 +266,20 @@ DeltaGenerator.add_rows(data)
 >>> d3 = foo(ref2)
     ''')
 
+    # Store data across reruns
+    col3.subheader('Store data across reruns')
+    col3.code('''
+st.title('Counter Example')
+if 'count' not in st.session_state:
+    st.session_state.count = 0
+
+increment = st.button('Increment')
+if increment:
+    st.session_state.count += 1
+
+st.write('Count = ', st.session_state.count)
+    ''')
+
     return None
 
 # Run main()

--- a/app.py
+++ b/app.py
@@ -106,6 +106,7 @@ st.header('My header')
 st.subheader('My sub')
 st.code('for i in range(8): foo()')
 * optional kwarg unsafe_allow_html = True
+st.caption('This is a small text')
     ''')
 
     # Display data


### PR DESCRIPTION
Based on changelog [here](https://docs.streamlit.io/en/stable/changelog.html) I'd identify the following things to be done:
- [x] 0.81.1 - Addition of `st.form()` and `st.form_submit_button()` 166ccdd
- [x] 0.81.1 - Addition of `st.caption()` 4a77a2d
- [x] 0.84.0 - Addition of `st.session_state()` 0050ab6
- [x] 0.86.0 - You can now use `st.columns`, `st.container` and `st.expander` without the `beta_` prefix. 166ccdd

Also updates the `README.md` e3c274b

Closes issue #8